### PR TITLE
Redirect parking payment link to locations page

### DIFF
--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -1,0 +1,9 @@
+export default function Locations() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-bold">Locations</h1>
+      <p>Available parking locations will appear here.</p>
+    </main>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -49,6 +50,12 @@ export default function Home() {
           >
             Read our docs
           </a>
+          <Link
+            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto"
+            href="/locations"
+          >
+            Parkvorgang bezahlen
+          </Link>
         </div>
       </main>
       <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">


### PR DESCRIPTION
## Summary
- add a Locations page
- link “Parkvorgang bezahlen” to the locations page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6891e7323eac83239b8e8d270980c4de